### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/src/script/modules/telemetry-blocker/index.ts
+++ b/src/script/modules/telemetry-blocker/index.ts
@@ -79,9 +79,18 @@ class TelemetryBlocker extends Module {
         }
 
 
-        if (url.includes(SPOTLIGHT_URL) && blockSpotlight) {
-          logInfo('Blocked Spotlight request:', url);
-          return new Response(null, { status: 204 }); // Return a successful but empty response
+        try {
+          const parsedUrl = new URL(url, window.location.origin);
+          if (
+            parsedUrl.origin === 'https://web.snapchat.com' &&
+            parsedUrl.pathname.startsWith('/context/spotlight') &&
+            blockSpotlight
+          ) {
+            logInfo('Blocked Spotlight request:', url);
+            return new Response(null, { status: 204 }); // Return a successful but empty response
+          }
+        } catch (e) {
+          // If URL parsing fails, do not block (fail open).
         }
 
         return this.originalFetch!(input, init);
@@ -103,9 +112,18 @@ class TelemetryBlocker extends Module {
           logInfo('Blocked XHR telemetry/metrics request:', urlString);
           return;
         }
-        if (urlString.includes(SPOTLIGHT_URL) && blockSpotlight) {
-          logInfo('Blocked XHR Spotlight request:', urlString);
-          return;
+        try {
+          const parsedUrl = new URL(urlString, window.location.origin);
+          if (
+            parsedUrl.origin === 'https://web.snapchat.com' &&
+            parsedUrl.pathname.startsWith('/context/spotlight') &&
+            blockSpotlight
+          ) {
+            logInfo('Blocked XHR Spotlight request:', urlString);
+            return;
+          }
+        } catch (e) {
+          // If URL parsing fails, do not block (fail open).
         }
 
         const effectiveAsync = async !== undefined ? async : true;


### PR DESCRIPTION
Potential fix for [https://github.com/mixtapejaxson/ChatTweak/security/code-scanning/4](https://github.com/mixtapejaxson/ChatTweak/security/code-scanning/4)

To fix the problem, the URL must be parsed and the relevant components—typically origin, host, or path—checked explicitly. 

- For the Spotlight blocker, instead of checking if `urlString.includes(SPOTLIGHT_URL)`, parse the URL and compare its `origin` and `pathname` to the intended Spotlight endpoint.
- Only block the request if both the origin matches `https://web.snapchat.com` and the path starts with `/context/spotlight` (or equals, depending on desired strictness).
- The best way is to use the standard `URL` Web API to parse `urlString`. This is available in all modern browsers and in Node, so it does not require any extra packages.
- Apply the same approach for the fetch override in case the same check is done elsewhere.
- Imports are not needed since `URL` is global, but wrap parsing in a try/catch to ensure malformed URLs don’t cause crashes.

Only lines within `src/script/modules/telemetry-blocker/index.ts` need changes, specifically the conditional on line 106. Show several lines of context on each side, and add new code only as required by the fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
